### PR TITLE
HaXML compat changes

### DIFF
--- a/HaXml-1.25.4/HaXml.cabal
+++ b/HaXml-1.25.4/HaXml.cabal
@@ -3,7 +3,7 @@ name:           HaXml
 version:        1.25.5
 x-revision:     3
 
-license:        LGPL
+license:        LGPL-2.1
 license-files:  COPYRIGHT, LICENCE-GPL, LICENCE-LGPL
 author:         Malcolm Wallace <Malcolm.Wallace@me.com>
 maintainer:     author

--- a/HaXml-1.25.4/src/Text/XML/HaXml/Schema/NameConversion.hs
+++ b/HaXml-1.25.4/src/Text/XML/HaXml/Schema/NameConversion.hs
@@ -8,7 +8,7 @@ import Text.XML.HaXml.Types
 import Text.XML.HaXml.Namespaces
 
 import Data.Char
-import Data.List
+import Data.List (intersperse, isPrefixOf)
 
 -- | An XName just holds the original XSD qualified name.  It does not
 --   ensure that the string conforms to any rules of the various Haskell

--- a/HaXml-1.25.4/src/Text/XML/HaXml/ShowXmlLazy.hs
+++ b/HaXml-1.25.4/src/Text/XML/HaXml/ShowXmlLazy.hs
@@ -13,7 +13,7 @@ import Prelude hiding (maybe,either)
 
 import qualified Text.XML.HaXml.XmlContent as X
 import Data.Maybe hiding (maybe)
-import Data.List
+import Data.List (intersperse)
 
 -- | Convert a fully-typed XML document to a string (without DTD).
 showXmlLazy :: X.XmlContent a => Bool -> a -> String

--- a/HaXml-1.25.4/src/tools/FpMLToHaskell.hs
+++ b/HaXml-1.25.4/src/tools/FpMLToHaskell.hs
@@ -14,7 +14,7 @@ import System.IO
 import Control.Monad
 import Control.Exception as E
 import System.Directory
-import Data.List
+import Data.List ((\\), intersperse, isSuffixOf, nubBy, nub)
 import Data.Maybe (fromMaybe,catMaybes)
 import Data.Function (on)
 import Data.Monoid (mconcat)

--- a/cpphs-1.20.9/cpphs.cabal
+++ b/cpphs-1.20.9/cpphs.cabal
@@ -1,7 +1,7 @@
 Name: cpphs
 Version: 1.20.9.1
 Copyright: 2004-2017, Malcolm Wallace
-License: LGPL
+License: LGPL-2.1
 License-File: LICENCE-LGPL
 Cabal-Version: >= 1.8
 Author: Malcolm Wallace <Malcolm.Wallace@me.com>

--- a/hscolour-1.24.4/hscolour.cabal
+++ b/hscolour-1.24.4/hscolour.cabal
@@ -4,7 +4,7 @@ Copyright: 2003-2017 Malcolm Wallace; 2006 Bjorn Bringert
 Maintainer: Malcolm Wallace
 Author: Malcolm Wallace
 Homepage: http://code.haskell.org/~malcolm/hscolour/
-License: LGPL
+License: LGPL-2.1
 License-file: LICENCE-LGPL
 Synopsis: Colourise Haskell code.
 Description:

--- a/polyparse-1.12/polyparse.cabal
+++ b/polyparse-1.12/polyparse.cabal
@@ -1,7 +1,7 @@
 name:           polyparse
 version:        1.13
 x-revision:     2
-license:        LGPL
+license:        LGPL-2.1
 license-files:   COPYRIGHT, LICENCE-LGPL, LICENCE-commercial
 copyright:      (c) 2006-2016 Malcolm Wallace
 author:         Malcolm Wallace <Malcolm.Wallace@me.com>


### PR DESCRIPTION
- set specific licenses in cabal files to avoid warnings from haskell.nix
- use explicit import list for Data.List to avoid issues with GHC-9.4